### PR TITLE
[SCRIPT] Block Animations

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,4 +11,4 @@ A collection of block editor level scripts (global, not tied to a block).
 
 ## Script Collection
 
-- [Script Name](./link-to-script-directory/README.md)
+- [Block Animations](./block-animations/README.md)

--- a/scripts/block-animations/README.md
+++ b/scripts/block-animations/README.md
@@ -1,0 +1,107 @@
+# Component Name
+
+Status: Alpha
+Version: 0.1-alpha
+Last Updated: 2023-08
+Component Created By: Geoff Dusome
+
+## What does this component do?
+
+The block animations script is used to add developer defined animations to blocks with settings defined in `theme.json`.
+
+## Example Usage
+
+### Moose Implementation 
+
+`block-animations.js` => `themes/core/assets/js/editor`
+`animate-on-scroll.js` => `themes/core/assets/js/theme`
+
+### `theme.json` Settings
+
+These settings can be overwritten in `theme.json`. If these values don't exist in `theme.json`, the script provides defaults.
+
+#### `animation`
+
+Used to define the names of the animations the developer would like to include in the project.
+
+```
+"animation": [
+	{ "label": "Test", "value": "test" },
+	{ "label": "Test 2", "value": "test-2" }
+]
+```
+
+#### `animationSpeeds`
+
+Used to define the values of how fast animations should run.
+
+```
+"animationSpeeds": [
+	{ "label": "Fast", "value": "0.2s" },
+	{ "label": "Slow", "value": "0.8s" }
+],
+```
+
+#### `animationDelays`
+
+Used to define the value of how long animations should be delayed before they run.
+
+```
+"animationDelays": [
+	{ "label": "Short", "value": "0.2s" },
+	{ "label": "Long", "value": "0.8s" }
+],
+```
+
+#### `animationEasings`
+
+Used to define the easings available to editors when defining animations on blocks.
+
+```
+"animationEasings": [
+	{ "label": "Ease In", "value": "ease-in" },
+	{ "label": "Ease Out", "value": "ease-out" }
+],
+```
+
+#### `animationIncludes`
+
+Used to define which blocks we want to have animations. If this property is set, only the blocks listed will get the animation settings.
+
+```
+"animationIncludes": [
+	"core/group",
+	"core/heading"
+],
+```
+
+#### `animationExcludes`
+
+Used to define which blocks we would like to exclude from having animation settings. If this property is set, the blocks listed **will not** have animation settings.
+
+```
+"animationExcludes": [
+	"core/group",
+	"core/heading"
+],
+```
+
+#### `animationTrigger`
+
+While not available for update in `theme.json`, this is an attribute set on every block that has animation properties set to define if the animation should run once per page load or every time the user scrolls past the element.
+
+#### `animationPosition`
+
+While not available for update in `theme.json`, this is an attribute set on every block that has animation properties set to define if animations on the block should run when the element is 25% in the viewport, or if animations should run with 100% of the element is in view. This is a good option to use if you're using animations on a smaller element. Alternatively, you could use the 25% option (default) with a small animation delay.
+
+### `animate-on-scroll.js`
+
+An additional script that pairs as the front-end handler for the block animations script. This script works on a class based system with `IntersectionObserver` where, if the element that has an animation defined has scrolled into view, that element will get an additional class the developer can use to apply animations to the block.
+
+The block animation script defines an additional class on blocks with animation for the "style" of animation (`tribe-animation-style-{style}`), which uses the `slug` property of the `animation` array's object.
+
+The block animation script defines three style properties on block with animation for the animation speed (`--tribe-animation-speed`), delay (`--tribe-animation-delay`), and easing (`--tribe-animation-easing`). You should be able to use these CSS custom properties within your animation styles to modify the default animation values.
+
+## Media
+
+- Demo Video: https://www.loom.com/share/13e7c18144f143f8b05960ecd5f135d7

--- a/scripts/block-animations/README.md
+++ b/scripts/block-animations/README.md
@@ -1,4 +1,4 @@
-# Component Name
+# Block Animations
 
 Status: Alpha
 Version: 0.1-alpha

--- a/scripts/block-animations/README.md
+++ b/scripts/block-animations/README.md
@@ -15,6 +15,7 @@ The block animations script is used to add developer defined animations to block
 
 `block-animations.js` => `themes/core/assets/js/editor`
 `animate-on-scroll.js` => `themes/core/assets/js/theme`
+`animation.pcss` => `themes/core/assets/pcss/global`
 
 ### `theme.json` Settings
 
@@ -101,6 +102,8 @@ An additional script that pairs as the front-end handler for the block animation
 The block animation script defines an additional class on blocks with animation for the "style" of animation (`tribe-animation-style-{style}`), which uses the `slug` property of the `animation` array's object.
 
 The block animation script defines three style properties on block with animation for the animation speed (`--tribe-animation-speed`), delay (`--tribe-animation-delay`), and easing (`--tribe-animation-easing`). You should be able to use these CSS custom properties within your animation styles to modify the default animation values.
+
+In this directory, there's a `animation.pcss` style file also included. This can be used as base for creating animations using these scripts.
 
 ## Media
 

--- a/scripts/block-animations/animate-on-scroll.js
+++ b/scripts/block-animations/animate-on-scroll.js
@@ -1,0 +1,79 @@
+/**
+ * @module
+ * @exports init
+ * @description functions for handling elements that should change on scroll
+ */
+
+const el = {};
+
+/**
+ * @function handleIntersection
+ *
+ * @description Callback function for when an element comes into view
+ *
+ * @param {*} entries
+ */
+const handleIntersection = ( entries ) => {
+	entries.forEach( ( entry ) => {
+		if ( entry.isIntersecting ) {
+			entry.target.classList.remove( 'is-exiting-view' );
+			entry.target.classList.add( 'is-scrolled-into-view' );
+			entry.target.classList.add( 'is-scrolled-into-view-first-time' );
+		} else {
+			entry.target.classList.remove( 'is-scrolled-into-view' );
+			entry.target.classList.add( 'is-exiting-view' );
+		}
+	} );
+};
+
+/**
+ * @function attachObservers
+ *
+ * @description attach intersection observers to elements
+ */
+const attachObservers = () => {
+	if ( el.aosElements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 0.25,
+		} );
+
+		el.aosElements.forEach( ( element ) => observer.observe( element ) );
+	}
+
+	if ( el.aosFullElements.length ) {
+		const observer = new window.IntersectionObserver( handleIntersection, {
+			threshold: 1,
+		} );
+
+		el.aosFullElements.forEach( ( element ) =>
+			observer.observe( element )
+		);
+	}
+};
+
+/**
+ * @function cacheElements
+ *
+ * @description Cache elements for this module
+ */
+const cacheElements = () => {
+	// grabs elements that should animate when the element is 25% in view
+	el.aosElements = document.querySelectorAll( '.is-animated-on-scroll' );
+
+	// grabs elements that should animate when the entire element is in view
+	el.aosFullElements = document.querySelectorAll(
+		'.is-animated-on-scroll-full'
+	);
+};
+
+/**
+ * @function init
+ *
+ * @description Kick off this module's functionality
+ */
+const init = () => {
+	cacheElements();
+	attachObservers();
+};
+
+export default init;

--- a/scripts/block-animations/animation.pcss
+++ b/scripts/block-animations/animation.pcss
@@ -1,0 +1,103 @@
+/* -------------------------------------------------------------------------
+ *
+ * Global: Animations
+ * Works with our block-animations code in core/assets/js/admin along with
+ * our FE IntersectionObserver in core/assets/js/utils/animate-on-scroll.js
+ * to create animations with settings on individual blocks
+ *
+ * ------------------------------------------------------------------------- */
+
+/* Setup default animation variables so they can be overridden per block */
+:root {
+	--tribe-animation-delay: 0s;
+	--tribe-animation-speed: 0.3s;
+	--tribe-animation-easing: ease;
+}
+
+/* -------------------------------------------------------------------------
+ * Animated Element / Block
+ * We set opacity to 0 here because all of our animations involve fades
+ * Also set the default transition for the block, if the "Animation should
+ * trigger every time the element is in the viewport" setting is checked,
+ * this transition will handle in & out animations.
+ * ------------------------------------------------------------------------- */
+
+.is-animated-on-scroll,
+.is-animated-on-scroll-full {
+	opacity: 0;
+	transition: opacity var(--tribe-animation-speed) var(--tribe-animation-delay) var(--tribe-animation-easing);
+
+	/* -------------------------------------------------------------------------
+	 * Fade In
+	 * Don't run "first time" animation if multiple is set
+	 * ------------------------------------------------------------------------- */
+
+	&.tribe-animation-style-fade-in.is-scrolled-into-view,
+	&:not(.tribe-animate-multiple).tribe-animation-style-fade-in.is-scrolled-into-view-first-time {
+		opacity: 1;
+	}
+
+	/* -------------------------------------------------------------------------
+	 * Fade In Up
+	 * Don't run "first time" animation if multiple is set
+	 * ------------------------------------------------------------------------- */
+
+	&.tribe-animation-style-fade-in-up {
+		transition-property: all;
+		transform: translateY(25%);
+
+		&.is-scrolled-into-view,
+		&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	/* -------------------------------------------------------------------------
+	 * Fade In Down
+	 * Don't run "first time" animation if multiple is set
+	 * ------------------------------------------------------------------------- */
+
+	&.tribe-animation-style-fade-in-down {
+		transition-property: all;
+		transform: translateY(-25%);
+
+		&.is-scrolled-into-view,
+		&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	/* -------------------------------------------------------------------------
+	 * Fade In Right
+	 * Don't run "first time" animation if multiple is set
+	 * ------------------------------------------------------------------------- */
+
+	&.tribe-animation-style-fade-in-right {
+		transition-property: all;
+		transform: translateX(-25%);
+
+		&.is-scrolled-into-view,
+		&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+			opacity: 1;
+			transform: translateX(0);
+		}
+	}
+
+	/* -------------------------------------------------------------------------
+	 * Fade In Left
+	 * Don't run "first time" animation if multiple is set
+	 * ------------------------------------------------------------------------- */
+
+	&.tribe-animation-style-fade-in-left {
+		transition-property: all;
+		transform: translateX(25%);
+
+		&.is-scrolled-into-view,
+		&:not(.tribe-animate-multiple).is-scrolled-into-view-first-time {
+			opacity: 1;
+			transform: translateX(0);
+		}
+	}
+}

--- a/scripts/block-animations/block-animation.js
+++ b/scripts/block-animations/block-animation.js
@@ -1,0 +1,411 @@
+/**
+ * @module block-animation
+ *
+ * @description handles setting up animation settings for blocks
+ *
+ * theme.json settings:
+ * "animation": [
+ * 		{ "label": "Test", "value": "test" },
+ * 		{ "label": "Test 2", "value": "test-2" }
+ * ],
+ * "animationSpeeds": [
+ * 		{ "label": "Fast", "value": "0.2s" },
+ * 		{ "label": "Slow", "value": "0.8s" }
+ * ],
+ * "animationDelays": [
+ * 		{ "label": "Short", "value": "0.2s" },
+ * 		{ "label": "Long", "value": "0.8s" }
+ * ],
+ * "animationEasings": [
+ * 		{ "label": "Ease In", "value": "ease-in" },
+ * 		{ "label": "Ease Out", "value": "ease-out" }
+ * ],
+ * "animationIncludes": [
+ * 		"core/group",
+ * 		"core/heading"
+ * ],
+ * "animationExcludes": [
+ * 		"core/group",
+ * 		"core/heading"
+ * ],
+ */
+
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import themeJson from '../../../theme.json';
+
+const state = {};
+
+/**
+ * @function applyAnimationProps
+ *
+ * @description updates props on the block with new animation settings
+ *
+ * @param {Object} props
+ * @param {Object} block
+ * @param {Object} attributes
+ *
+ * @return {Object} updated props object
+ */
+const applyAnimationProps = ( props, block, attributes ) => {
+	// return default props if block isn't in the includes array
+	if (
+		state.includes.length > 0 &&
+		! state.includes.includes( block.name )
+	) {
+		return props;
+	}
+
+	// return default props if block is in the excludes array
+	if ( state.excludes.length > 0 && state.excludes.includes( block.name ) ) {
+		return props;
+	}
+
+	const {
+		animationStyle,
+		animationSpeed,
+		animationDelay,
+		animationEasing,
+		animationTrigger,
+		animationPosition,
+	} = attributes;
+
+	if ( animationStyle === undefined || animationStyle === 'none' ) {
+		return props;
+	}
+
+	props.className =
+		animationPosition !== undefined && animationPosition
+			? `${ props.className } tribe-animation-style-${ animationStyle } is-animated-on-scroll-full`
+			: `${ props.className } tribe-animation-style-${ animationStyle } is-animated-on-scroll`;
+
+	if ( animationSpeed !== undefined && animationSpeed ) {
+		props.style = {
+			...props.style,
+			'--tribe-animation-speed': animationSpeed,
+		};
+	}
+
+	if ( animationDelay !== undefined && animationDelay ) {
+		props.style = {
+			...props.style,
+			'--tribe-animation-delay': animationDelay,
+		};
+	}
+
+	if ( animationEasing !== undefined && animationEasing ) {
+		props.style = {
+			...props.style,
+			'--tribe-animation-easing': animationEasing,
+		};
+	}
+
+	if ( animationTrigger !== undefined && animationTrigger ) {
+		props.className = `${ props.className } tribe-animate-multiple`;
+	}
+
+	return props;
+};
+
+/**
+ * @function animationControls
+ *
+ * @description creates component that overrides the edit functionality of the block with new animation controls
+ */
+const animationControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		const { attributes, setAttributes, isSelected, name } = props;
+
+		// return default Edit function if block isn't in the includes array
+		if ( state.includes.length > 0 && ! state.includes.includes( name ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		// return default Edit function if block is in the excludes array
+		if ( state.excludes.length > 0 && state.excludes.includes( name ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const {
+			animationStyle,
+			animationSpeed,
+			animationDelay,
+			animationEasing,
+			animationTrigger,
+			animationPosition,
+		} = attributes;
+
+		let blockClass =
+			attributes.className !== undefined ? attributes.className : '';
+		const blockStyles = { ...props.style };
+
+		if ( animationStyle !== undefined && animationStyle !== 'none' ) {
+			blockClass =
+				animationPosition !== undefined && animationPosition
+					? `${ blockClass } tribe-animation-style-${ animationStyle } is-animated-on-scroll-full`
+					: `${ blockClass } tribe-animation-style-${ animationStyle } is-animated-on-scroll`;
+
+			if ( animationSpeed !== undefined && animationSpeed ) {
+				blockStyles[ '--tribe-animation-speed' ] = animationSpeed;
+			}
+
+			if ( animationDelay !== undefined && animationDelay ) {
+				blockStyles[ '--tribe-animation-delay' ] = animationDelay;
+			}
+
+			if ( animationEasing !== undefined && animationEasing ) {
+				blockStyles[ '--tribe-animation-easing' ] = animationEasing;
+			}
+
+			if ( animationTrigger !== undefined && animationTrigger ) {
+				blockClass = `${ blockClass } tribe-animate-multiple`;
+			}
+		}
+
+		const blockProps = {
+			...props,
+			attributes: {
+				...attributes,
+				className: blockClass,
+			},
+			style: blockStyles,
+		};
+
+		return (
+			<Fragment>
+				<BlockEdit { ...blockProps } />
+				{ isSelected && (
+					<InspectorControls>
+						<PanelBody
+							title={ __( 'Block Animations', 'tribe' ) }
+							initialOpen={ false }
+						>
+							<SelectControl
+								label={ __( 'Animation Style', 'tribe' ) }
+								value={ animationStyle ?? 'none' }
+								help={ __(
+									'Animation style is the type of animation you want to display.',
+									'tribe'
+								) }
+								onChange={ ( newValue ) => {
+									setAttributes( {
+										animationStyle: newValue,
+									} );
+								} }
+								options={ state.animations }
+							/>
+							<SelectControl
+								label={ __( 'Animation Speed', 'tribe' ) }
+								value={ animationSpeed ?? '0.3s' }
+								help={ __(
+									'Animation speed is the speed at which the animation should run.'
+								) }
+								onChange={ ( newValue ) =>
+									setAttributes( {
+										animationSpeed: newValue,
+									} )
+								}
+								options={ state.speed }
+							/>
+							<SelectControl
+								label={ __( 'Animation Delay', 'tribe' ) }
+								value={ animationDelay ?? '0s' }
+								help={ __(
+									'Animation delay adds extra time before the animation starts.',
+									'tribe'
+								) }
+								onChange={ ( newValue ) =>
+									setAttributes( {
+										animationDelay: newValue,
+									} )
+								}
+								options={ state.delays }
+							/>
+							<SelectControl
+								label={ __( 'Animation Easing', 'tribe' ) }
+								value={ animationEasing ?? 'ease' }
+								help={ __(
+									'Animation easing determines what easing function the animation should use.',
+									'tribe'
+								) }
+								onChange={ ( newValue ) =>
+									setAttributes( {
+										animationEasing: newValue,
+									} )
+								}
+								options={ state.easings }
+							/>
+							<ToggleControl
+								label={ __(
+									'Animation should trigger every time the element is in the viewport',
+									'tribe'
+								) }
+								help={ __(
+									'Default functionality is to trigger the animation once.',
+									'tribe'
+								) }
+								checked={ !! animationTrigger }
+								onChange={ ( newValue ) =>
+									setAttributes( {
+										animationTrigger: newValue,
+									} )
+								}
+							/>
+							<ToggleControl
+								label={ __(
+									'Animation should trigger when the element is completely in the viewport',
+									'tribe'
+								) }
+								help={ __(
+									'Default functionality is to trigger the animation when 25% of it is in the viewport.',
+									'tribe'
+								) }
+								checked={ !! animationPosition }
+								onChange={ ( newValue ) =>
+									setAttributes( {
+										animationPosition: newValue,
+									} )
+								}
+							/>
+						</PanelBody>
+					</InspectorControls>
+				) }
+			</Fragment>
+		);
+	};
+}, 'animationControls' );
+
+/**
+ * @function addAnimationAttributes
+ *
+ * @description add new attributes to blocks for animation settings
+ *
+ * @param {Object} settings
+ * @param {string} name
+ *
+ * @return {Object} returns updates settings object
+ */
+const addAnimationAttributes = ( settings, name ) => {
+	// return default settings if block isn't in the includes array
+	if ( state.includes.length > 0 && ! state.includes.includes( name ) ) {
+		return settings;
+	}
+
+	// return default settings if block is in the excludes array
+	if ( state.excludes.length > 0 && state.excludes.includes( name ) ) {
+		return settings;
+	}
+
+	if ( settings?.attributes !== undefined ) {
+		settings.attributes = {
+			...settings.attributes,
+			animationStyle: {
+				type: 'string',
+			},
+			animationSpeed: {
+				type: 'string',
+			},
+			animationDelay: {
+				type: 'string',
+			},
+			animationEasing: {
+				type: 'string',
+			},
+			animationTrigger: {
+				type: 'boolean',
+			},
+			animationPosition: {
+				type: 'boolean',
+			},
+		};
+	}
+
+	return settings;
+};
+
+/**
+ * @function registerFilters
+ *
+ * @description register block filters for adding animation controls
+ */
+const registerFilters = () => {
+	addFilter(
+		'blocks.registerBlockType',
+		'tribe/add-animation-options',
+		addAnimationAttributes
+	);
+
+	addFilter(
+		'editor.BlockEdit',
+		'tribe/animation-advanced-control',
+		animationControls
+	);
+
+	addFilter(
+		'blocks.getSaveContent.extraProps',
+		'tribe/apply-animation-classes',
+		applyAnimationProps
+	);
+};
+
+/**
+ * @function initializeSettings
+ *
+ * @description pull settings from theme.json or add default settings
+ *
+ * @todo work with design to handle defining these defaults
+ * @todo do we need to handle translations if pulling from theme.json?
+ */
+const initializeSettings = () => {
+	state.animations = themeJson?.settings?.animations ?? [
+		{ label: __( 'None', 'tribe' ), value: 'none' },
+		{ label: __( 'Fade In', 'tribe' ), value: 'fade-in' },
+		{ label: __( 'Fade In Up', 'tribe' ), value: 'fade-in-up' },
+		{ label: __( 'Fade In Down', 'tribe' ), value: 'fade-in-down' },
+		{ label: __( 'Fade In Right', 'tribe' ), value: 'fade-in-right' },
+		{ label: __( 'Fade In Left', 'tribe' ), value: 'fade-in-left' },
+	];
+	state.speeds = themeJson?.settings?.animationSpeeds ?? [
+		{ label: __( 'Extra Slow', 'tribe' ), value: '0.7s' },
+		{ label: __( 'Slow', 'tribe' ), value: '0.5s' },
+		{ label: __( 'Normal', 'tribe' ), value: '0.3s' },
+		{ label: __( 'Fast', 'tribe' ), value: '0.2s' },
+		{ label: __( 'Extra Fast', 'tribe' ), value: '0.1s' },
+	];
+	state.delays = themeJson?.settings?.animationDelays ?? [
+		{ label: __( 'None', 'tribe' ), value: '0s' },
+		{ label: __( 'Extra Short', 'tribe' ), value: '0.1s' },
+		{ label: __( 'Short', 'tribe' ), value: '0.2s' },
+		{ label: __( 'Medium', 'tribe' ), value: '0.3s' },
+		{ label: __( 'Long', 'tribe' ), value: '0.5s' },
+		{ label: __( 'Extra Long', 'tribe' ), value: '0.7s' },
+	];
+	state.easings = themeJson?.settings?.animationEasings ?? [
+		{ label: __( 'Ease', 'tribe' ), value: 'ease' },
+		{ label: __( 'Ease In', 'tribe' ), value: 'ease-in' },
+		{ label: __( 'Ease Out', 'tribe' ), value: 'ease-out' },
+		{ label: __( 'Ease In Out', 'tribe' ), value: 'ease-in-out' },
+		{ label: __( 'Linear', 'tribe' ), value: 'linear' },
+	];
+	state.includes = themeJson.settings.animationIncludes ?? [];
+	state.excludes = themeJson.settings.animationExcludes ?? [];
+};
+
+/**
+ * @function init
+ *
+ * @description initializes this modules functions
+ */
+const init = () => {
+	// initialize settings
+	initializeSettings();
+
+	// handle registering block filters
+	registerFilters();
+};
+
+export default init;


### PR DESCRIPTION
# Block Animations

**NOTE: This is a lateral move from a PR defined in the original Moose repo: https://github.com/moderntribe/moose/pull/67**

## What does this do/fix?

Adds block animations script that can be used to add developer defined animations to blocks with settings defined in `theme.json`.

## How can this be quickly implemented for testing?

`block-animations.js` => `themes/core/assets/js/editor` => call in editor `ready.js`
`animate-on-scroll.js` => `themes/core/assets/js/theme` => call in theme `ready.js`
`animation.pcss` => `themes/core/assets/pcss/global` => call in `theme.pcss` imports

## Media

- Demo Video: https://www.loom.com/share/13e7c18144f143f8b05960ecd5f135d7