### PR TITLE
[BLOCK] Slider

### DIFF
--- a/block-library/README.md
+++ b/block-library/README.md
@@ -11,4 +11,4 @@ A collection of custom blocks.
 
 ## Block Collection
 
-- [Block Name](./link-to-block-directory/README.md)
+- [Slider](./slider/README.md)

--- a/block-library/slider/README.md
+++ b/block-library/slider/README.md
@@ -1,0 +1,25 @@
+# Slider
+
+Status: Alpha
+Version: 0.1-alpha
+Last Updated: 2023-09
+Component Created By: Geoff Dusome
+
+## What does this component do?
+
+This block needs more definition but currently this component consists of two blocks, one Slider Container block and one Slider Slide block. 
+
+## Example Usage
+
+This component needs more definition before we can define usage.
+
+### Moose Implementation
+
+1. Copy directory to the `themes/core/blocks/tribe/` directory.
+1. Add the `tribe/slider-container` and `tribe/slider-slide` blocks to the `self::TYPES` array in `plugins/core/src/Blocks/Blocks_Definer.php`.
+1. Run `npm run dist` to build the blocks.
+
+## Media
+
+- Screenshot: 
+- Demo Video: 

--- a/block-library/slider/slider-container/block.json
+++ b/block-library/slider/slider-container/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/slider-container",
+	"version": "0.1.0",
+	"title": "Slider Container",
+	"category": "theme",
+	"icon": "images-alt2",
+	"description": "A container block for a Swiper slider.",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": false
+		}
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
+	"editorStyle": [ "file:./index.css", "file:./style-index.css"],
+	"style": [ "file:./index.css", "file:./style-index.css"]
+}

--- a/block-library/slider/slider-container/edit.js
+++ b/block-library/slider/slider-container/edit.js
@@ -1,0 +1,69 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+/* eslint-disable */
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { useRef, useEffect } from '@wordpress/element';
+import { Navigation, Pagination, A11y } from 'swiper/modules';
+import Swiper from 'swiper';
+import swiperSettings from './swiper.json';
+/* eslint-enable */
+
+const TEMPLATE = [
+	[
+		'tribe/slider-slide',
+		{},
+		[ [ 'core/paragraph', { placeholder: 'Enter slide content...' } ] ],
+	],
+	[
+		'tribe/slider-slide',
+		{},
+		[ [ 'core/paragraph', { placeholder: 'Enter slide content...' } ] ],
+	],
+];
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	const block = useRef( null );
+	const blockProps = useBlockProps();
+	const { children } = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'tribe/slider-slide' ],
+		template: TEMPLATE,
+	} );
+
+	useEffect( () => {
+		if (
+			block.current &&
+			! block.current.classList.contains( 'swiper-initialized' )
+		) {
+			new Swiper( '.swiper', {
+				modules: [ Navigation, Pagination, A11y ],
+				...swiperSettings,
+			} );
+		}
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<div ref={ block } className="swiper">
+				<div className="swiper-wrapper">{ children }</div>
+				<div className="swiper-pagination"></div>
+				<div className="swiper-button-next"></div>
+				<div className="swiper-button-prev"></div>
+			</div>
+		</div>
+	);
+}

--- a/block-library/slider/slider-container/index.js
+++ b/block-library/slider/slider-container/index.js
@@ -1,0 +1,46 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.pcss';
+
+/**
+ * Import Swiper styles
+ */
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import Save from './save';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save: Save,
+} );

--- a/block-library/slider/slider-container/save.js
+++ b/block-library/slider/slider-container/save.js
@@ -1,0 +1,30 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Save() {
+	return (
+		<div { ...useBlockProps.save() }>
+			<div className="swiper">
+				<div className="swiper-wrapper">
+					<InnerBlocks.Content />
+				</div>
+				<div className="swiper-pagination"></div>
+				<div className="swiper-button-prev"></div>
+				<div className="swiper-button-next"></div>
+			</div>
+		</div>
+	);
+}

--- a/block-library/slider/slider-container/style.pcss
+++ b/block-library/slider/slider-container/style.pcss
@@ -1,0 +1,14 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-tribe-slider-container {
+
+	/* set small height for the slider for easier testing */
+	.swiper {
+		height: 300px;
+	}
+}

--- a/block-library/slider/slider-container/swiper.json
+++ b/block-library/slider/slider-container/swiper.json
@@ -1,0 +1,13 @@
+{
+	"init": true,
+	"loop": true,
+	"navigation": {
+		"nextEl": ".swiper-button-next",
+		"prevEl": ".swiper-button-prev",
+		"clickable": true
+	},
+	"pagination": {
+		"el": ".swiper-pagination",
+		"clickable": true
+	}
+}

--- a/block-library/slider/slider-container/view.js
+++ b/block-library/slider/slider-container/view.js
@@ -1,0 +1,11 @@
+import { ready } from 'utils/events';
+import { Navigation, Pagination, A11y } from 'swiper/modules';
+import Swiper from 'swiper';
+import swiperSettings from './swiper.json';
+
+ready( () => {
+	new Swiper( '.swiper', {
+		modules: [ Navigation, Pagination, A11y ],
+		...swiperSettings,
+	} );
+} );

--- a/block-library/slider/slider-slide/block.json
+++ b/block-library/slider/slider-slide/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/slider-slide",
+	"version": "0.1.0",
+	"title": "Slider Slide",
+	"category": "theme",
+	"icon": "format-image",
+	"description": "A slide block for a Swiper slider.",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"parent": [ "tribe/slider-container" ],
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css"
+}

--- a/block-library/slider/slider-slide/edit.js
+++ b/block-library/slider/slider-slide/edit.js
@@ -1,0 +1,27 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return (
+		<div className="swiper-slide">
+			<div { ...blockProps }>
+				<InnerBlocks />
+			</div>
+		</div>
+	);
+}

--- a/block-library/slider/slider-slide/index.js
+++ b/block-library/slider/slider-slide/index.js
@@ -1,0 +1,39 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.pcss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import Save from './save';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save: Save,
+} );

--- a/block-library/slider/slider-slide/save.js
+++ b/block-library/slider/slider-slide/save.js
@@ -1,0 +1,23 @@
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Save() {
+	return (
+		<div className="swiper-slide">
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/block-library/slider/slider-slide/style.pcss
+++ b/block-library/slider/slider-slide/style.pcss
@@ -1,0 +1,21 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+/**
+ * this block doesn't get any wrapping classes as it only displays
+ * in the slider container block, we'll wrap it in that block here
+ * so we don't have any global issues
+ */
+.wp-block-tribe-slider-container {
+
+	/* center everything in the slider for easier testing */
+	.swiper-slide {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}


### PR DESCRIPTION
# Slider

## What does this do/fix?

This block needs more definition but currently this component consists of two blocks, one Slider Container block and one Slider Slide block. 

## How can this be quickly implemented for testing?

1. Add `swiper` as a dependency in the project
1. Run `npm install` to install the dependency
2. `webpack.config.js` [will need to be updated](https://github.com/moderntribe/moose/blob/49d1c8a4957e7f9264b0e34cf5dfe9c3e810758c/webpack.config.js#L54-L95) to allow `view.js` scripts within blocks (if we decide to go this direction)
1. Copy directory to the `themes/core/blocks/tribe/` directory.
1. Add the `tribe/slider-container` and `tribe/slider-slide` blocks to the `self::TYPES` array in `plugins/core/src/Blocks/Blocks_Definer.php`.
1. Run `npm run dist` to build the blocks.

## TODO

- [ ] Define with ST & DE what a slider block would look like as a base
- [ ] Define with ST & DE how a slider block would function by default on the FE & within the editor
- [ ] Define the Slider Container block to be extensible with some Swiper options built into the block that change how the slider behaves without needing developer intervention.
- [ ] Define the Slider Slide block to be extensible with different patterns so that the one block can function for all uses

## Media

- Screenshots / Demo Video: 

