### PR TITLE
[BLOCK] Color Theme

### DIFF
--- a/block-library/README.md
+++ b/block-library/README.md
@@ -12,3 +12,4 @@ A collection of custom blocks.
 ## Block Collection
 
 - [Terms](./terms/README.md)
+- [Color Theme](./color-theme/README.md)

--- a/block-library/color-theme/README.md
+++ b/block-library/color-theme/README.md
@@ -1,0 +1,32 @@
+# Terms Block
+
+Status: Alpha
+Version: 0.1-alpha
+Last Updated: 2024-06
+Component Created By: Geoff Dusome
+
+## What does this component do?
+
+The color theme block is intended to be used to apply color themes to specific sets of blocks. Whether that be a card component, or an entire section. This color theme block is intended to be used in place of a simple Group block. This is so that Group blocks can be used for their normal purposes and the color theme block can be used in place of the Group block where a color theme is needed (normally decided by design).
+
+## Example Usage
+
+This block is intended to replace the core Group block within WordPress to provide a better approach to color theming.
+
+### Moose Implementation
+
+Very simple implementation:
+
+1. Copy contents of `block` directory to the `themes/core/blocks/tribe/color-theme` directory. 
+2. Add the `tribe/color-theme` block to the `TYPES` array in the `plugins/core/src/Blocks/Blocks_Definer.php` file.
+3. Build the block using `npm run dist`.
+
+### Block Styles
+
+#### `Default`
+
+The "Default" block style for the Color Theme block is a white background with black text. A white background will always be applied.
+
+#### `Dark`
+
+The "Dark" block style for the Color Theme block is a black background with white text.

--- a/block-library/color-theme/block/block.json
+++ b/block-library/color-theme/block/block.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/color-theme",
+	"version": "0.1.0",
+	"title": "Color Theme",
+	"category": "theme",
+	"icon": "admin-appearance",
+	"description": "A Group block replacement for applying color themes",
+	"styles": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{
+			"name": "dark",
+			"label": "Dark"
+		}
+	],
+	"supports": {
+		"html": false,
+		"alignCustom": [
+			"wide",
+			"grid",
+			"full"
+		],
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"layout": true
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css"
+}

--- a/block-library/color-theme/block/edit.js
+++ b/block-library/color-theme/block/edit.js
@@ -1,0 +1,11 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks />
+		</div>
+	);
+}

--- a/block-library/color-theme/block/index.js
+++ b/block-library/color-theme/block/index.js
@@ -1,0 +1,19 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import './style.pcss';
+
+import Edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} );

--- a/block-library/color-theme/block/save.js
+++ b/block-library/color-theme/block/save.js
@@ -1,0 +1,11 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function save() {
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/block-library/color-theme/block/style.pcss
+++ b/block-library/color-theme/block/style.pcss
@@ -1,0 +1,27 @@
+/* -------------------------------------------------------------------------
+ *
+ * Block - Color Theme - Styles - FE / Editor
+ *
+ * ------------------------------------------------------------------------- */
+
+.wp-block-tribe-color-theme {
+
+	/* set variables */
+	--theme-text-color: var(--color-black);
+	--theme-background-color: var(--color-white);
+	--theme-accent-color: var(--color-royal-blue);
+
+	/* apply variables */
+	background-color: var(--theme-background-color);
+	color: var(--theme-text-color);
+
+	.color-theme-accent-color {
+		color: var(--theme-accent-color) !important;
+	}
+
+	&.is-style-dark {
+		--theme-text-color: var(--color-white);
+		--theme-background-color: var(--color-black);
+		--theme-accent-color: var(--color-neutral-10);
+	}
+}


### PR DESCRIPTION
# Color Theme Block

## What does this do/fix?

**The purpose of the Color Theme block is to provide a more straightforward way for clients & us to handle color theming.** Additionally, this block will allow us to control _where_ color themes are controlled from. As an example, If I have a simple pattern where I want all blocks instead of a section to change their text color when I update the section at the top level, then I'd only add a Color Theme block at the top level. If I wanted an inner element to be themed differently than a parent element. I would use nested Color Theme blocks to achieve this. 

I've added an additional "accent" color option to the block, but if we feel this is overkill for the base version of this block we can remove that. I've also been asked by design to remove a background on a color theme when a color theme is necessary on top of background images (like used in the Cover block). In the past, I've just added an additional class that overrides the `background-color` property to `transparent` using `!important`.

Please see the notes in the [Color Theme Custom Block ticket here](https://moderntribe.atlassian.net/browse/MOOSE-128) for a bit more background & information on the block.

## How can this be quickly implemented for testing?

1. Copy contents of `block` directory to the `themes/core/blocks/tribe/color-theme` directory. 
2. Add the `tribe/color-theme` block to the `TYPES` array in the `plugins/core/src/Blocks/Blocks_Definer.php` file.
3. Build the block using `npm run dist`.

## Media

- Block Screenshot: http://p.tri.be/i/FClhMu
- Demo video: https://www.loom.com/share/7af911c8786b43e7af51aa6839aaf760

