### PR TITLE
[FILTER] Post Featured Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ A collection of custom blocks.
 [scripts/README.md](./scripts/README.md)
 
 A collection of block editor level scripts (global, not tied to a block).
+
+## Filters
+
+[filters/README.md]('./filters/README.md)
+
+A collection of block filters that override front end markup for a block.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ A collection of block editor level scripts (global, not tied to a block).
 
 ## Filters
 
-[filters/README.md]('./filters/README.md)
+[filters/README.md](./filters/README.md)
 
 A collection of block filters that override front end markup for a block.

--- a/filters/README.md
+++ b/filters/README.md
@@ -1,0 +1,14 @@
+# Filters
+
+A collection of PHP block filter overrides.
+
+## Guidelines
+
+1. Filters should be created in their own directory with a descriptive name.
+1. Filter directories should utilize the provided `README-sample.md` file in the root directory.
+1. Link to the filter README file below!
+1. Filters should follow the version naming scheme of `0.1-alpha` for in progress blocks, `1.0-beta` for complete filters that may need polishing, and `>1.0` for stable versions of the filter.
+
+## Block Collection
+
+- [Post Featured Image Placeholder Filter](./post-featured-image/README.md)

--- a/filters/README.md
+++ b/filters/README.md
@@ -9,6 +9,6 @@ A collection of PHP block filter overrides.
 1. Link to the filter README file below!
 1. Filters should follow the version naming scheme of `0.1-alpha` for in progress blocks, `1.0-beta` for complete filters that may need polishing, and `>1.0` for stable versions of the filter.
 
-## Block Collection
+## Filter Collection
 
 - [Post Featured Image Placeholder Filter](./post-featured-image/README.md)

--- a/filters/post-featured-image/Post_Featured_Image_Filter.php
+++ b/filters/post-featured-image/Post_Featured_Image_Filter.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Blocks\Filters;
+
+use Tribe\Plugin\Blocks\Filters\Contracts\Block_Content_Filter;
+
+class Post_Featured_Image_Filter extends Block_Content_Filter {
+
+	public const BLOCK = 'core/post-featured-image';
+
+	public function filter_block_content( string $block_content, array $parsed_block, object $block ): string {
+		if ( $block_content === '' ) {
+			$styles   = wp_style_engine_get_styles( $parsed_block['attrs']['style'] );
+			$classes  = isset( $parsed_block['attrs']['align'] ) ? 'align' . $parsed_block['attrs']['align'] : '';
+			$classes .= isset( $parsed_block['attrs']['className'] ) ? ' ' . $parsed_block['attrs']['className'] : '';
+
+			return '<figure class="wp-block-post-featured-image '. $classes .'" style="'. $styles['css'] .'"><img class="wp-post-image" width="1680" height="945" src="'. esc_url( get_template_directory_uri() . '/assets/media/featured-image-placeholder.jpg' ) .'" alt="Post placeholder image" style="width: 100%; height: 100%; object-fit: cover;"></figure>';
+		}
+
+		return $block_content;
+	}
+
+}

--- a/filters/post-featured-image/README.md
+++ b/filters/post-featured-image/README.md
@@ -5,6 +5,12 @@ Version: 0.1-alpha
 Last Updated: 2024-07
 Component Created By: Geoff
 
+## TODOS
+
+- [ ] Support multiple post types with a different image placeholder for each post types.
+- [ ] Allow ability to globally set placeholder image(s) via custom meta field. 
+- [ ] Support ability for multiple placeholder images set to randomly show one out of an array.
+
 ## What does this component do?
 
 This filter targets the post featured image block in order to add a placeholder image if the featured image isn't set. Note that filters only work on the front-end of the website.

--- a/filters/post-featured-image/README.md
+++ b/filters/post-featured-image/README.md
@@ -1,0 +1,21 @@
+# Post Featured Image Placeholder Filter
+
+Status: Alpha
+Version: 0.1-alpha
+Last Updated: 2024-07
+Component Created By: Geoff
+
+## What does this component do?
+
+This filter targets the post featured image block in order to add a placeholder image if the featured image isn't set. Note that filters only work on the front-end of the website.
+
+## Example Usage
+
+1. Add the filter to the `plugins/core/src/Blocks/Filters/` directory under the name `Post_Featured_Image_Filter.php`. 
+2. Add the new filter to the `self::FILTERS` array in the `Blocks_Definer.php` file in the `/Blocks` directory using `DI\get( Post_Featured_Image_Filter::class ),`.
+3. Add your placeholder image to the `themes/core/assets/media/` directory and ensure the naming of the file added matches the naming for the image within the `Post_Featured_Image_Filter.php` file.
+4. When viewing a Post Featured Image block on the front-end of the website, you should now see your placeholder image, rather than nothing.
+
+## Media
+
+- Screenshot: http://p.tri.be/i/r7cFGc


### PR DESCRIPTION
# Post Featured Image Placeholder Filter

## What does this do/fix?

This filter targets the post featured image block in order to add a placeholder image if the featured image isn't set. Note that filters only work on the front-end of the website.

## How can this be quickly implemented for testing?

1. Add the filter to the `plugins/core/src/Blocks/Filters/` directory under the name `Post_Featured_Image_Filter.php`. 
2. Add the new filter to the `self::FILTERS` array in the `Blocks_Definer.php` file in the `/Blocks` directory using `DI\get( Post_Featured_Image_Filter::class ),`.
3. Add your placeholder image to the `themes/core/assets/media/` directory and ensure the naming of the file added matches the naming for the image within the `Post_Featured_Image_Filter.php` file.
4. When viewing a Post Featured Image block on the front-end of the website, you should now see your placeholder image, rather than nothing.

## Media

- Screenshots / Demo Video: http://p.tri.be/i/r7cFGc

