### PR TITLE
[BLOCK] Tabs

### DIFF
--- a/block-library/README.md
+++ b/block-library/README.md
@@ -13,3 +13,4 @@ A collection of custom blocks.
 
 - [Terms](./terms/README.md)
 - [Color Theme](./color-theme/README.md)
+- [Tabs](./tabs/README.md)

--- a/block-library/tabs/README.md
+++ b/block-library/tabs/README.md
@@ -28,8 +28,7 @@ The tabs block has a FE dependency on the `delegate` library (https://www.npmjs.
 
 Very simple implementation:
 
-1. Add `delegate` as a project dependency in your `package.json` file
-1. Run `npm install` to install the dependency 
+1. Run `npm i delegate` to add the required dependency. 
 2. Copy contents of `blocks` directory to the `themes/core/blocks/tribe` directory. 
 2. Add the `tribe/tabs` and `tribe/tab` blocks to the `TYPES` array in the `plugins/core/src/Blocks/Blocks_Definer.php` file.
 3. Build the blocks using `npm run dist`.

--- a/block-library/tabs/README.md
+++ b/block-library/tabs/README.md
@@ -5,6 +5,11 @@ Version: 0.1-alpha
 Last Updated: 2024-07
 Component Created By: Geoff Dusome
 
+## TODOS
+
+- [ ] Remove `delegate` dependency from the `view.js` script in the `tabs` block.
+- [ ] Explore block optimizations and alternative implementations
+
 ## What does this component do?
 
 The Tabs block is a set of two blocks used in a parent/child relationship. The Tabs block is the container and main driver of the block. The Tabs block contains all of the editor functionality and styling. The Tab block is the holder of the tab content and acts as an InnerBlocks wrapper.

--- a/block-library/tabs/README.md
+++ b/block-library/tabs/README.md
@@ -1,0 +1,29 @@
+# Tabs Block
+
+Status: Alpha
+Version: 0.1-alpha
+Last Updated: 2024-07
+Component Created By: Geoff Dusome
+
+## What does this component do?
+
+The Tabs block is a set of two blocks used in a parent/child relationship. The Tabs block is the container and main driver of the block. The Tabs block contains all of the editor functionality and styling. The Tab block is the holder of the tab content and acts as an InnerBlocks wrapper.
+
+## Example Usage
+
+Both the editor view and FE view have been created fairly opinionated but both are very easily updated to match what would be required of your project. The editor view is different than the FE view in this case due to the difference in FE & Editor experience. 
+
+- When you first add the block to the page (http://p.tri.be/i/SER4TN), the block will be populated with one tab. 
+- New tabs can be added via the "Add New Tab" button. 
+- Tabs can be removed by clicking the "X" icon within each tab title.
+- Clicking each tab title should display the tab content for that tab title.
+- Tabs can be reordered ONLY via the block list view at this time. We were not able to come up with a solution where we can click & drag to reorder the tabs within the block.
+- Tab content can be entered by clicking each tab title and adding blocks to the tab content for that tab.
+
+### Moose Implementation
+
+Very simple implementation:
+
+1. Copy contents of `blocks` directory to the `themes/core/blocks/tribe` directory. 
+2. Add the `tribe/tabs` and `tribe/tab` blocks to the `TYPES` array in the `plugins/core/src/Blocks/Blocks_Definer.php` file.
+3. Build the blocks using `npm run dist`.

--- a/block-library/tabs/README.md
+++ b/block-library/tabs/README.md
@@ -20,10 +20,16 @@ Both the editor view and FE view have been created fairly opinionated but both a
 - Tabs can be reordered ONLY via the block list view at this time. We were not able to come up with a solution where we can click & drag to reorder the tabs within the block.
 - Tab content can be entered by clicking each tab title and adding blocks to the tab content for that tab.
 
+### Dependencies
+
+The tabs block has a FE dependency on the `delegate` library (https://www.npmjs.com/package/delegate).
+
 ### Moose Implementation
 
 Very simple implementation:
 
-1. Copy contents of `blocks` directory to the `themes/core/blocks/tribe` directory. 
+1. Add `delegate` as a project dependency in your `package.json` file
+1. Run `npm install` to install the dependency 
+2. Copy contents of `blocks` directory to the `themes/core/blocks/tribe` directory. 
 2. Add the `tribe/tabs` and `tribe/tab` blocks to the `TYPES` array in the `plugins/core/src/Blocks/Blocks_Definer.php` file.
 3. Build the blocks using `npm run dist`.

--- a/block-library/tabs/blocks/tab/block.json
+++ b/block-library/tabs/blocks/tab/block.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/tab",
+	"version": "0.1.0",
+	"title": "Tab",
+	"category": "theme",
+	"description": "Child of Tabs block",
+	"icon": "text-page",
+	"parent": [ "tribe/tabs" ],
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": false,
+			"padding": true
+		}
+	},
+	"attributes": {
+		"blockId": {
+			"type": "string",
+			"default": ""
+		},
+		"tabLabel": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"usesContext": [ "tribe/tabs/currentActiveTabInstanceId" ],
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css"
+}

--- a/block-library/tabs/blocks/tab/edit.js
+++ b/block-library/tabs/blocks/tab/edit.js
@@ -1,0 +1,27 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { useInstanceId } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
+
+import './editor.pcss';
+
+export default function Edit( { context, setAttributes } ) {
+	const activeTab = context[ 'tribe/tabs/currentActiveTabInstanceId' ];
+	const instanceId = useInstanceId( Edit, 'tab-content' );
+	const blockProps = useBlockProps( {
+		className: activeTab === instanceId ? 'active-tab' : '',
+	} );
+
+	useEffect( () => {
+		setAttributes( {
+			blockId: instanceId,
+		} );
+	}, [ instanceId, setAttributes ] );
+
+	const TAB_TEMPLATE = [ [ 'core/paragraph' ] ];
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks template={ TAB_TEMPLATE } />
+		</div>
+	);
+}

--- a/block-library/tabs/blocks/tab/editor.pcss
+++ b/block-library/tabs/blocks/tab/editor.pcss
@@ -1,0 +1,7 @@
+.wp-block-tribe-tab {
+	display: none;
+
+	&.active-tab {
+		display: block;
+	}
+}

--- a/block-library/tabs/blocks/tab/index.js
+++ b/block-library/tabs/blocks/tab/index.js
@@ -1,0 +1,34 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import Edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	icon: (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M1.5 2.25H7.62488H9.125H13.3749H14.5024H20.2524V6.5H22.25V18.75C22.25 19.413 21.9866 20.0489 21.5178 20.5178C21.0489 20.9866 20.413 21.25 19.75 21.25H4C3.33696 21.25 2.70107 20.9866 2.23223 20.5178C1.76339 20.0489 1.5 19.413 1.5 18.75V2.25ZM18.7524 6.5V3.75H14.8749V6.5H18.7524ZM3 3.75H7.62488V7.25H7.625V8H20.75V18.75C20.75 19.0152 20.6446 19.2696 20.4571 19.4571C20.2696 19.6446 20.0152 19.75 19.75 19.75H4C3.73478 19.75 3.48043 19.6446 3.29289 19.4571C3.10536 19.2696 3 19.0152 3 18.75V3.75ZM9.125 6.5V3.75H13.0024V6.5H9.125Z"
+				fill="black"
+			/>
+		</svg>
+	),
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} );

--- a/block-library/tabs/blocks/tab/save.js
+++ b/block-library/tabs/blocks/tab/save.js
@@ -1,0 +1,21 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function save( props ) {
+	const {
+		attributes: { blockId },
+	} = props;
+
+	const blockProps = useBlockProps.save( {
+		id: blockId,
+		role: 'tabpanel',
+		tabindex: '0',
+		hidden: true,
+		'aria-labelledby': 'button-' + blockId,
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/block-library/tabs/blocks/tabs/block.json
+++ b/block-library/tabs/blocks/tabs/block.json
@@ -1,0 +1,49 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "tribe/tabs",
+	"version": "0.1.0",
+	"title": "Tabs",
+	"category": "theme",
+	"description": "Allows creation of tabbed content",
+	"icon": "slides",
+	"supports": {
+		"html": false,
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"currentActiveTabInstanceId": "tab-content-0",
+			"tabs": [
+				{
+					"clientId": "12345",
+					"id": "tab-content-0",
+					"label": "Tab Label",
+					"isActive": true
+				}
+			]
+		}
+	},
+	"attributes": {
+		"currentActiveTabInstanceId": {
+			"type": "string",
+			"default": ""
+		},
+		"tabs": {
+			"type": "array",
+			"default": []
+		}
+	},
+	"providesContext": {
+		"tribe/tabs/currentActiveTabInstanceId": "currentActiveTabInstanceId"
+	},
+	"textdomain": "tribe",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
+}

--- a/block-library/tabs/blocks/tabs/edit.js
+++ b/block-library/tabs/blocks/tabs/edit.js
@@ -1,0 +1,219 @@
+/**
+ * WordPress Dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import {
+	useBlockProps,
+	RichText,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { Button, Flex, FlexItem } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { SVG, Path } from '@wordpress/primitives';
+
+import './editor.pcss';
+
+export default function Edit( { clientId, attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const dispatch = useDispatch( 'core/block-editor' );
+	const { removeBlocks } = useDispatch( 'core/block-editor' );
+	const select = useSelect( 'core/block-editor' );
+	const innerBlocks = select.getBlocks( clientId );
+	const { currentActiveTabInstanceId, tabs } = attributes;
+
+	// Update the current active tab to the client Id of the first tab
+	useEffect( () => {
+		if ( innerBlocks.length === 0 || currentActiveTabInstanceId !== '' ) {
+			return;
+		}
+
+		setAttributes( {
+			currentActiveTabInstanceId: innerBlocks[ 0 ].attributes.blockId,
+		} );
+	}, [ innerBlocks, setAttributes, currentActiveTabInstanceId ] );
+
+	/**
+	 * @function updateTabLabel
+	 *
+	 * @description Dispatch action to matching tab to update its label
+	 *
+	 * @param {string} tabLabel
+	 * @param {string} tabClientId
+	 */
+	const updateTabLabel = ( tabLabel, tabClientId ) => {
+		dispatch.updateBlockAttributes( tabClientId, { tabLabel } );
+	};
+
+	/**
+	 * @function addNewTab
+	 *
+	 * @description adds a new tab and an InnerBlock to match
+	 *
+	 * @param {number} positionToAdd
+	 */
+	const addNewTab = ( positionToAdd = innerBlocks.length ) => {
+		// create block
+		const newTab = createBlock( 'tribe/tab' );
+
+		// add new tab
+		dispatch
+			.insertBlock( newTab, positionToAdd, clientId, true )
+			.then( () => {
+				// dispatch will return us a promise which we can use to set our new active tab instanceId
+				const newInstanceId =
+					select.getBlocks( clientId )[ positionToAdd ].attributes
+						.blockId;
+
+				// set new tab as active
+				setAttributes( {
+					currentActiveTabInstanceId: newInstanceId,
+				} );
+			} );
+	};
+
+	/**
+	 * @function deleteTab
+	 *
+	 * @description handles removing tab & InnerBlock based on index
+	 *
+	 * @param {number} index
+	 * @param {string} tabInstanceId
+	 * @param {string} tabClientId
+	 */
+	const deleteTab = ( index, tabInstanceId, tabClientId ) => {
+		// remove block from InnerBlocks
+		removeBlocks( tabClientId );
+
+		// Fetch new inner blocks
+		const newInnerBlocks = select.getBlocks( clientId );
+
+		// Add a new tab if we've deleted the last one
+		if ( newInnerBlocks.length === 0 ) {
+			addNewTab( newInnerBlocks.length );
+
+			return;
+		}
+
+		// decide which block should be the new selected block
+		let newActiveTabInstanceId = currentActiveTabInstanceId;
+
+		if ( newActiveTabInstanceId === tabInstanceId ) {
+			// if we want the first block, show new "first block", any other tab, use the "next" tab
+			newActiveTabInstanceId =
+				index === 0
+					? newInnerBlocks[ index ].attributes.blockId
+					: newInnerBlocks[ index - 1 ].attributes.blockId;
+		}
+
+		setAttributes( {
+			currentActiveTabInstanceId: newActiveTabInstanceId,
+		} );
+	};
+
+	// setup inner block props and add classname to wrapper
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-tribe-tabs__tab-content',
+		},
+		{
+			allowedBlocks: [ 'tribe/tab' ],
+			template: [ [ 'tribe/tab' ] ],
+			renderAppender: false,
+		}
+	);
+
+	// set new tab state when innerBlocks or currentActiveTabInstanceId changes
+	useEffect( () => {
+		const data = innerBlocks.map( ( tab ) => {
+			return {
+				clientId: tab.clientId,
+				id: tab.attributes.blockId,
+				buttonId: 'button-' + tab.attributes.blockId,
+				label: tab.attributes.tabLabel,
+				isActive: currentActiveTabInstanceId === tab.attributes.blockId,
+			};
+		} );
+
+		setAttributes( {
+			tabs: data,
+		} );
+	}, [ innerBlocks, currentActiveTabInstanceId, setAttributes ] );
+
+	return (
+		<div { ...blockProps }>
+			<Flex
+				className="wp-block-tribe-tabs__tabs"
+				align="center"
+				justify="flex-start"
+			>
+				{ tabs.map( ( tab, index ) => (
+					<FlexItem
+						className={
+							'wp-block-tribe-tabs__tab' +
+							( currentActiveTabInstanceId === tab.id
+								? ' active-tab'
+								: '' )
+						}
+						key={ 'tab-' + tab.id }
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'flex-start',
+							gap: 'var(--spacer-10)',
+						} }
+						onClick={ () => {
+							setAttributes( {
+								currentActiveTabInstanceId: tab.id,
+							} );
+						} }
+					>
+						<RichText
+							tagName="span"
+							className="wp-block-tribe-tabs__tab-label"
+							value={ tab.label }
+							onChange={ ( value ) =>
+								updateTabLabel( value, tab.clientId )
+							}
+							allowedFormats={ [] }
+							placeholder={ __( 'Tab Label', 'tribe' ) }
+						/>
+						<Button
+							className="wp-block-tribe-tabs__tab-delete"
+							variant="link"
+							onClick={ ( e ) => {
+								e.stopPropagation();
+								deleteTab( index, tab.id, tab.clientId );
+							} }
+						>
+							<span
+								style={ {
+									display: 'inline-flex',
+									width: '24px',
+									height: '24px',
+								} }
+							>
+								<SVG
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 24 24"
+								>
+									<Path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z" />
+								</SVG>
+							</span>
+						</Button>
+					</FlexItem>
+				) ) }
+				<FlexItem
+					className="wp-block-tribe-tabs__add"
+					justify="flex-start"
+				>
+					<Button variant="primary" onClick={ () => addNewTab() }>
+						{ __( 'Add New Tab', 'tribe' ) }
+					</Button>
+				</FlexItem>
+			</Flex>
+			<div { ...innerBlocksProps } />
+		</div>
+	);
+}

--- a/block-library/tabs/blocks/tabs/edit.js
+++ b/block-library/tabs/blocks/tabs/edit.js
@@ -23,7 +23,24 @@ export default function Edit( { clientId, attributes, setAttributes } ) {
 	const innerBlocks = select.getBlocks( clientId );
 	const { currentActiveTabInstanceId, tabs } = attributes;
 
-	// Update the current active tab to the client Id of the first tab
+	/**
+	 * setup inner block props and add classname to wrapper
+	 */
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-tribe-tabs__tab-content',
+		},
+		{
+			allowedBlocks: [ 'tribe/tab' ],
+			template: [ [ 'tribe/tab' ] ],
+			renderAppender: false,
+		}
+	);
+
+	/**
+	 * Update the current active tab to the client Id of the first tab
+	 * This will only run once when the block is first added to the editor
+	 */
 	useEffect( () => {
 		if ( innerBlocks.length === 0 || currentActiveTabInstanceId !== '' ) {
 			return;
@@ -33,6 +50,25 @@ export default function Edit( { clientId, attributes, setAttributes } ) {
 			currentActiveTabInstanceId: innerBlocks[ 0 ].attributes.blockId,
 		} );
 	}, [ innerBlocks, setAttributes, currentActiveTabInstanceId ] );
+
+	/**
+	 * set new tab state when innerBlocks or currentActiveTabInstanceId changes
+	 */
+	useEffect( () => {
+		const data = innerBlocks.map( ( tab ) => {
+			return {
+				clientId: tab.clientId,
+				id: tab.attributes.blockId,
+				buttonId: 'button-' + tab.attributes.blockId,
+				label: tab.attributes.tabLabel,
+				isActive: currentActiveTabInstanceId === tab.attributes.blockId,
+			};
+		} );
+
+		setAttributes( {
+			tabs: data,
+		} );
+	}, [ innerBlocks, currentActiveTabInstanceId, setAttributes ] );
 
 	/**
 	 * @function updateTabLabel
@@ -111,35 +147,6 @@ export default function Edit( { clientId, attributes, setAttributes } ) {
 			currentActiveTabInstanceId: newActiveTabInstanceId,
 		} );
 	};
-
-	// setup inner block props and add classname to wrapper
-	const innerBlocksProps = useInnerBlocksProps(
-		{
-			className: 'wp-block-tribe-tabs__tab-content',
-		},
-		{
-			allowedBlocks: [ 'tribe/tab' ],
-			template: [ [ 'tribe/tab' ] ],
-			renderAppender: false,
-		}
-	);
-
-	// set new tab state when innerBlocks or currentActiveTabInstanceId changes
-	useEffect( () => {
-		const data = innerBlocks.map( ( tab ) => {
-			return {
-				clientId: tab.clientId,
-				id: tab.attributes.blockId,
-				buttonId: 'button-' + tab.attributes.blockId,
-				label: tab.attributes.tabLabel,
-				isActive: currentActiveTabInstanceId === tab.attributes.blockId,
-			};
-		} );
-
-		setAttributes( {
-			tabs: data,
-		} );
-	}, [ innerBlocks, currentActiveTabInstanceId, setAttributes ] );
 
 	return (
 		<div { ...blockProps }>

--- a/block-library/tabs/blocks/tabs/editor.pcss
+++ b/block-library/tabs/blocks/tabs/editor.pcss
@@ -1,0 +1,56 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-tribe-tabs__tabs {
+	gap: 0 !important;
+	border: 1px solid var(--theme-border-color, var(--color-black));
+}
+
+.wp-block-tribe-tabs__tab {
+	position: relative;
+	padding: var(--spacer-20);
+	cursor: pointer;
+	border-right: 1px solid var(--theme-border-color, var(--color-black));
+
+	&.active-tab {
+		position: relative;
+
+		&::after {
+			content: "";
+			display: block;
+			width: 100%;
+			height: 1px;
+			position: absolute;
+			bottom: -1px;
+			left: 0;
+			background-color: var(--theme-background-color, var(--color-white));
+		}
+	}
+}
+
+.wp-block-tribe-tabs__tab-label {
+	cursor: text;
+}
+
+.wp-block-tribe-tabs__tab-delete {
+	padding: 0 !important;
+	color: var(--theme-text-color, var(--color-text)) !important;
+
+	&:hover,
+	&:focus {
+		color: var(--theme-accent-color, var(--wp-admin-theme-color)) !important;
+	}
+}
+
+.wp-block-tribe-tabs__add {
+	margin-left: var(--spacer-20);
+}
+
+.wp-block-tribe-tabs__tab-content {
+	border: 1px solid var(--theme-border-color, var(--color-black));
+	border-top: 0;
+	padding: var(--spacer-20);
+}

--- a/block-library/tabs/blocks/tabs/index.js
+++ b/block-library/tabs/blocks/tabs/index.js
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import './style.pcss';
+
+import Edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	icon: (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M1.5 2.25H7.62488H9.125H13.3749H14.5024H20.2524V6.5H22.25V18.75C22.25 19.413 21.9866 20.0489 21.5178 20.5178C21.0489 20.9866 20.413 21.25 19.75 21.25H4C3.33696 21.25 2.70107 20.9866 2.23223 20.5178C1.76339 20.0489 1.5 19.413 1.5 18.75V2.25ZM18.7524 6.5V3.75H14.8749V6.5H18.7524ZM3 3.75H7.62488V7.25H7.625V8H20.75V18.75C20.75 19.0152 20.6446 19.2696 20.4571 19.4571C20.2696 19.6446 20.0152 19.75 19.75 19.75H4C3.73478 19.75 3.48043 19.6446 3.29289 19.4571C3.10536 19.2696 3 19.0152 3 18.75V3.75ZM9.125 6.5V3.75H13.0024V6.5H9.125Z"
+				fill="black"
+			/>
+		</svg>
+	),
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} );

--- a/block-library/tabs/blocks/tabs/save.js
+++ b/block-library/tabs/blocks/tabs/save.js
@@ -1,0 +1,44 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function save( props ) {
+	const blockProps = {
+		...useBlockProps.save(),
+		'data-js': 'tabs-block',
+	};
+	const {
+		attributes: { tabs },
+	} = props;
+
+	// TODO: add control for accessible label
+
+	return (
+		<section { ...blockProps }>
+			<div className="wp-block-tribe-tabs__tab-nav">
+				<div className="wp-block-tribe-tabs__tab-list" role="tablist">
+					{ tabs.map( ( tab, index ) => {
+						return (
+							<button
+								key={ tab.id }
+								id={ tab.buttonId }
+								type="button"
+								className="wp-block-tribe-tabs__tab-item-button"
+								aria-controls={ tab.id }
+								role="tab"
+								aria-selected={ index === 0 ? 'true' : 'false' }
+								tabIndex={ index === 0 ? '-1' : false }
+							>
+								{ tab.label !== ''
+									? tab.label
+									: __( 'Tab Label', 'tribe' ) }
+							</button>
+						);
+					} ) }
+				</div>
+			</div>
+			<div className="tab-content">
+				<InnerBlocks.Content />
+			</div>
+		</section>
+	);
+}

--- a/block-library/tabs/blocks/tabs/style.pcss
+++ b/block-library/tabs/blocks/tabs/style.pcss
@@ -1,0 +1,52 @@
+.wp-block-tribe-tabs__tab-nav {
+	overflow-x: auto;
+}
+
+.wp-block-tribe-tabs__tab-list {
+	display: inline-flex;
+	align-items: stretch;
+	justify-content: center;
+	gap: var(--spacer-40);
+	min-width: 100%;
+	position: relative;
+	padding: 0;
+	margin-top: 0;
+	margin-bottom: 0;
+	border-bottom: 3px solid var(--theme-border-color, var(--color-neutral-20));
+}
+
+/* keep this for allowing previous versions of the block to still work */
+.wp-block-tribe-tabs__tab-item {
+	display: flex;
+	justify-content: center;
+}
+
+.wp-block-tribe-tabs__tab-item-button {
+
+	@mixin t-display-xx-small;
+	display: flex;
+	justify-content: center;
+	position: relative;
+	z-index: 2;
+	padding: var(--spacer-20);
+	background-color: transparent;
+	border: 0;
+	cursor: pointer;
+	white-space: nowrap;
+	color: var(--theme-text-color, var(--color-text));
+
+	&[aria-selected="true"] {
+		color: var(--theme-accent-color, var(--color-text));
+
+		&::after {
+			content: "";
+			display: block;
+			width: 100%;
+			height: 3px;
+			position: absolute;
+			top: 100%;
+			left: 0;
+			background-color: var(--theme-accent-color, var(--color-text));
+		}
+	}
+}

--- a/block-library/tabs/blocks/tabs/view.js
+++ b/block-library/tabs/blocks/tabs/view.js
@@ -1,9 +1,7 @@
 import delegate from 'delegate';
 
-import { ready } from 'utils/events.js';
-
 const el = {
-	tabBlocks: null,
+	tabBlocks: document.querySelectorAll( '[data-js="tabs-block"]' ),
 };
 
 /**
@@ -150,23 +148,13 @@ const bindEvents = () => {
 };
 
 /**
- * @function cacheElements
- *
- * @description save elements for later use
- */
-const cacheElements = () => {
-	el.tabBlocks = document.querySelectorAll( '[data-js="tabs-block"]' );
-};
-
-/**
  * @function init
  *
  * @description kick off the functionality
  */
 const init = () => {
-	cacheElements();
 	bindEvents();
 	initializeTabBlocks();
 };
 
-ready( init );
+init();

--- a/block-library/tabs/blocks/tabs/view.js
+++ b/block-library/tabs/blocks/tabs/view.js
@@ -1,0 +1,172 @@
+import delegate from 'delegate';
+
+import { ready } from 'utils/events.js';
+
+const el = {
+	tabBlocks: null,
+};
+
+/**
+ * @function initializeTabBlocks
+ *
+ * @description remove hidden attributes from the first tab panel in the block. Unfortunately we can't do this in the save() function due to block editor constraints
+ */
+const initializeTabBlocks = () => {
+	el.tabBlocks.forEach( ( tabBlock ) => {
+		const firstTabPanel = tabBlock.querySelector(
+			'[role="tabpanel"]:first-child'
+		);
+
+		firstTabPanel.removeAttribute( 'hidden' );
+	} );
+};
+
+/**
+ * @function handleTabListKeyDown
+ *
+ * @description handle keyboard events within the tablist
+ *
+ * @param {*} e
+ */
+const handleTabListKeyDown = ( e ) => {
+	// bail early if the key event isn't the left or right arrow keys
+	const keyEvents = [ 'ArrowLeft', 'ArrowRight' ];
+
+	if ( ! keyEvents.includes( e.key ) ) {
+		return;
+	}
+
+	// get element indicies to determine where to go next
+	const container = e.delegateTarget.closest( '[data-js="tabs-block"]' );
+	const tabButtons = [ ...container.querySelectorAll( '[role="tab"]' ) ];
+	const currentIndex = tabButtons.indexOf(
+		container.ownerDocument.activeElement
+	);
+	const lastIndex = tabButtons.length - 1;
+
+	// handle right arrow key
+	if ( e.key === 'ArrowRight' ) {
+		// If the current trigger is the last, then cycle to the first. Otherwise, go to the next.
+		const nextIndex = currentIndex + 1 > lastIndex ? 0 : currentIndex + 1;
+		switchTabs( tabButtons[ nextIndex ] );
+		tabButtons[ nextIndex ].focus();
+	}
+
+	// handle left arrow key
+	if ( e.key === 'ArrowLeft' ) {
+		// If the current trigger is the first, then cycle to the last. Otherwise, go to the previous.
+		const prevIndex = currentIndex - 1 < 0 ? lastIndex : currentIndex - 1;
+		switchTabs( tabButtons[ prevIndex ] );
+		tabButtons[ prevIndex ].focus();
+	}
+};
+
+/**
+ * @function hideTabPanel
+ *
+ * @description actions required to hide a particular tab
+ *
+ * @param {*} tab
+ * @param {*} trigger
+ */
+const hideTabPanel = ( tab, trigger ) => {
+	tab.setAttribute( 'hidden', true );
+	trigger.setAttribute( 'aria-selected', 'false' );
+	trigger.setAttribute( 'tabindex', '-1' );
+};
+
+/**
+ * @function showTabPanel
+ *
+ * @description actions required to show a particular tab
+ *
+ * @param {*} tab
+ * @param {*} trigger
+ */
+const showTabPanel = ( tab, trigger ) => {
+	tab.removeAttribute( 'hidden' );
+	trigger.setAttribute( 'aria-selected', 'true' );
+	trigger.removeAttribute( 'tabindex' );
+};
+
+/**
+ * @function switchTabs
+ *
+ * @description handles switching the selected tab
+ *
+ * @param {*} targetTabButton
+ */
+const switchTabs = ( targetTabButton ) => {
+	// check if aria-controls is set
+	const selectedTabId = targetTabButton.getAttribute( 'aria-controls' );
+
+	if ( ! selectedTabId ) {
+		return;
+	}
+
+	// grab all tab panels
+	const container = targetTabButton.closest( '[data-js="tabs-block"]' );
+	const tabs = container.querySelectorAll( '[role="tabpanel"]' );
+
+	tabs.forEach( ( tab ) => {
+		// grab tab button via the aria-labelledby attribute
+		const tabButton = container.querySelector(
+			`#${ tab.getAttribute( 'aria-labelledby' ) }`
+		);
+
+		// determine if we should hide or show this specific panel
+		( tab.id === selectedTabId ? showTabPanel : hideTabPanel )(
+			tab,
+			tabButton
+		);
+	} );
+};
+
+/**
+ * @function handleTabClick
+ *
+ * @description handle click on tab element
+ *
+ * @param {*} e
+ */
+const handleTabClick = ( e ) =>
+	e.delegateTarget.getAttribute( 'aria-selected' ) === 'false'
+		? switchTabs( e.delegateTarget )
+		: false;
+
+/**
+ * @function bindEvents
+ *
+ * @description bind events to elements related to the module
+ */
+const bindEvents = () => {
+	delegate( el.tabBlocks, '[role="tab"]', 'click', handleTabClick );
+	delegate(
+		el.tabBlocks,
+		'[role="tablist"]',
+		'keydown',
+		handleTabListKeyDown
+	);
+};
+
+/**
+ * @function cacheElements
+ *
+ * @description save elements for later use
+ */
+const cacheElements = () => {
+	el.tabBlocks = document.querySelectorAll( '[data-js="tabs-block"]' );
+};
+
+/**
+ * @function init
+ *
+ * @description kick off the functionality
+ */
+const init = () => {
+	cacheElements();
+	bindEvents();
+	initializeTabBlocks();
+};
+
+ready( init );


### PR DESCRIPTION
# Component Title

## What does this do/fix?

The Tabs block is a set of two blocks used in a parent/child relationship. The Tabs block is the container and main driver of the block. The Tabs block contains all of the editor functionality and styling. The Tab block is the holder of the tab content and acts as an InnerBlocks wrapper.

The tabs block has a FE dependency on the `delegate` library (https://www.npmjs.com/package/delegate). I'd like to remove this dependency if possible, but I didn't have time to do so for the project and I didn't have time to do so before getting this PR up. If someone wants to take a stab by my guest!

## Todo

- [ ] Possibly remove `delegate` dependency?
- [ ] Maybe remove opinionated styling on both the FE & editor?

## How can this be quickly implemented for testing?

1. Add `delegate` as a project dependency in your `package.json` file
1. Run `npm install` to install the dependency 
2. Copy contents of `blocks` directory to the `themes/core/blocks/tribe` directory. 
2. Add the `tribe/tabs` and `tribe/tab` blocks to the `TYPES` array in the `plugins/core/src/Blocks/Blocks_Definer.php` file.
3. Build the blocks using `npm run dist`.

## Media

- Block Screenshot: http://p.tri.be/i/SER4TN

