### PR TITLE
[MOOSE-249] Add and update deployment workflows

### DIFF
--- a/workflows/pantheon/README.md
+++ b/workflows/pantheon/README.md
@@ -8,7 +8,8 @@ as well as the `PANTHEON_SITE_MACHINE_NAME` variable to use this deployment in y
 
 ## Setup Instructions
 1. Copy and paste the `deploy-pantheon.yml` file into your project's `.github/workflows` directory to take advantage of this action.
-2. This workflow relies on the `composer-install` action [from Moose]([url](https://github.com/moderntribe/moose/tree/main/.github/actions)).
+2. Remove `node_modules` line from `.deploy/deploy-exclude.txt`.
+3. This workflow relies on the `composer-install` action [from ModernPress]([url](https://github.com/moderntribe/modernpress/tree/main/.github/actions)).
 Be sure your project includes the action, or that you've replicated that functionality in your local project.
-3. You will need to define the `PANTHEON_SSH_KEY`, `PANTHEON_MACHINE_TOKEN`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`,
+4. You will need to define the `PANTHEON_SSH_KEY`, `PANTHEON_MACHINE_TOKEN`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`,
 and `OP_ITEM` secrets, as well as `PANTHEON_SITE_MACHINE_NAME` variable to use this deployment in your project.

--- a/workflows/pantheon/README.md
+++ b/workflows/pantheon/README.md
@@ -1,0 +1,14 @@
+# Pantheon Deployment GitHub Actions
+
+## Pantheon Deployment Workflows
+A single deployment workflow interfaces with the main destination (`dev`) as well as any multi-dev environments.
+You will need to update the `PANTHEON_SSH_KEY` ([doc](https://docs.pantheon.io/ssh-keys)), `PANTHEON_MACHINE_TOKEN`
+([doc](https://docs.pantheon.io/machine-tokens)), 1Password secrets (`OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, `OP_ITEM`),
+as well as the `PANTHEON_SITE_MACHINE_NAME` variable to use this deployment in your project.
+
+## Setup Instructions
+1. Copy and paste the `deploy-pantheon.yml` file into your project's `.github/workflows` directory to take advantage of this action.
+2. This workflow relies on the `composer-install` action [from Moose]([url](https://github.com/moderntribe/moose/tree/main/.github/actions)).
+Be sure your project includes the action, or that you've replicated that functionality in your local project.
+3. You will need to define the `PANTHEON_SSH_KEY`, `PANTHEON_MACHINE_TOKEN`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`,
+and `OP_ITEM` secrets, as well as `PANTHEON_SITE_MACHINE_NAME` variable to use this deployment in your project.

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -27,41 +27,13 @@ jobs:
       - name: Check out build branch
         uses: actions/checkout@v6
 
-      - name: 'Configure PHP environment'
-        uses: shivammathur/setup-php@v2
+      # Composer install
+      - name: 'Composer install'
+        uses: ./.github/actions/composer-install
         with:
-          php-version: '8.4'
-
-      - name: 'Get composer cache directory'
-        id: composer-cache
-        shell: bash
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: 'Cache composer dependencies'
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: 'Install 1Password CLI'
-        uses: 1password/install-cli-action@v2
-
-      - name: 'Create auth.json via 1Password CLI'
-        shell: bash
-        env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OP_VAULT: ${{ secrets.OP_VAULT }}
           OP_ITEM: ${{ secrets.OP_ITEM }}
-        run: op inject -i auth.template.json -o auth.json
-
-      - name: 'Install Composer'
-        shell: bash
-        run: |
-          composer install --optimize-autoloader --no-dev
-          rm auth.json
 
       # Set up node version
       - name: Set up node

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -1,5 +1,5 @@
 name: Deploy to Pantheon
-run-name: 'Deploy to Pantheon `${{ inputs.target_env }}`: `${{ github.head_ref || github.ref_name }}`'
+run-name: 'Deploy `${{ github.head_ref || github.ref_name }}` to `${{ inputs.target_env }}`'
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.target_env }}

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Set up node version
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -2,7 +2,7 @@ name: Deploy to Pantheon
 run-name: 'Deploy to Pantheon `${{ inputs.target_env }}`: `${{ github.head_ref || github.ref_name }}`'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.target_env }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ inputs.target_env }}
   cancel-in-progress: true
 
 on:

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -1,0 +1,129 @@
+name: Deploy to Pantheon
+run-name: 'Deploy to Pantheon `${{ inputs.target_env }}`: `${{ github.head_ref || github.ref_name }}`'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.target_env }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_env:
+        default: 'dev'
+        description: 'Target environment [dev]'
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      deployments: write
+      contents: read
+
+    steps:
+      # Get Build Repository
+      - name: Check out build branch
+        uses: actions/checkout@v6
+
+      - name: 'Configure PHP environment'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+
+      - name: 'Get composer cache directory'
+        id: composer-cache
+        shell: bash
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: 'Cache composer dependencies'
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: 'Install 1Password CLI'
+        uses: 1password/install-cli-action@v2
+
+      - name: 'Create auth.json via 1Password CLI'
+        shell: bash
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_VAULT: ${{ secrets.OP_VAULT }}
+          OP_ITEM: ${{ secrets.OP_ITEM }}
+        run: op inject -i auth.template.json -o auth.json
+
+      - name: 'Install Composer'
+        shell: bash
+        run: |
+          composer install --optimize-autoloader --no-dev
+          rm auth.json
+
+      # Set up node version
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          check-latest: true
+
+      # NPM install all dependencies and build assets
+      - name: NPM install and build assets
+        run: |
+          npm install
+          npm run dist
+
+      # NPM install production dependencies
+      - name: NPM install production dependencies
+        run: npm install --omit=dev --omit=optional
+
+      - name: Cleanup
+        run: |
+          rm -rf \
+            .deploy \
+            .github/lighthouse \
+            .github/workflows \
+            .github/PULL_REQUEST_TEMPLATE.md \
+            .lefthook \
+            .vscode \
+            dev \
+            docs \
+            tests \
+            .editorconfig \
+            .env.testing.slic \
+            .eslintrc.json \
+            .gitignore \
+            .lando.yml \
+            .nvmrc \
+            .prettierignore \
+            .stylelintrc.json \
+            auth.template.json \
+            browsersync.config.js \
+            codeception.dist.yml \
+            composer.json \
+            composer.lock \
+            lefthook.yml \
+            local-config-sample.json \
+            local-config-sample.php \
+            package-lock.json \
+            package.json \
+            phpcs.xml.dist \
+            phpstan.neon.dist \
+            postcss.config.js \
+            Procfile \
+            webpack.config.js
+
+      ##########
+      ### DEPLOY: Use the Pantheon GitHub Action.
+
+      - name: Deploy to Pantheon
+        uses: pantheon-systems/push-to-pantheon@0.9.0
+        with:
+          ssh_key: ${{ secrets.PANTHEON_SSH_KEY }}
+          machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+          site: ${{ vars.PANTHEON_SITE_MACHINE_NAME }}
+          target_env: ${{ inputs.target_env }}

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -54,40 +54,7 @@ jobs:
         run: npm install --omit=dev --omit=optional
 
       - name: Cleanup
-        run: |
-          rm -rf \
-            .deploy \
-            .github/lighthouse \
-            .github/workflows \
-            .github/PULL_REQUEST_TEMPLATE.md \
-            .lefthook \
-            .vscode \
-            dev \
-            docs \
-            tests \
-            .editorconfig \
-            .env.testing.slic \
-            .eslintrc.json \
-            .gitignore \
-            .lando.yml \
-            .nvmrc \
-            .prettierignore \
-            .stylelintrc.json \
-            auth.template.json \
-            browsersync.config.js \
-            codeception.dist.yml \
-            composer.json \
-            composer.lock \
-            lefthook.yml \
-            local-config-sample.json \
-            local-config-sample.php \
-            package-lock.json \
-            package.json \
-            phpcs.xml.dist \
-            phpstan.neon.dist \
-            postcss.config.js \
-            Procfile \
-            webpack.config.js
+        run: cat .deploy/deploy-exclude.txt | xargs rm -rf
 
       ##########
       ### DEPLOY: Use the Pantheon GitHub Action.

--- a/workflows/pantheon/deploy-pantheon.yml
+++ b/workflows/pantheon/deploy-pantheon.yml
@@ -54,7 +54,19 @@ jobs:
         run: npm install --omit=dev --omit=optional
 
       - name: Cleanup
-        run: cat .deploy/deploy-exclude.txt | xargs rm -rf
+        run: |
+          # Add files in .deploy/deploy-exclude.txt to .gitignore before deploy
+          # Skip comments/empty lines, append each pattern to .gitignore
+          echo "" >> .gitignore
+          echo "# Temporary excludes for Pantheon push (CI only - not committed to GitHub)" >> .gitignore
+          grep -v '^#' .deploy/deploy-exclude.txt | grep -v '^$' >> .gitignore
+
+          # Optional: Show what was added (for debugging/verbose output)
+          echo "Appended the following to .gitignore:"
+          tail -n +$(($(wc -l < .gitignore) - $(wc -l < .deploy/deploy-exclude.txt | awk '{print $1}') + 2)) .gitignore
+
+          # No git add/commit here — the push-to-pantheon action will handle committing/pushing
+          # If needed, you can force-add .gitignore if the action requires it, but usually not
 
       ##########
       ### DEPLOY: Use the Pantheon GitHub Action.

--- a/workflows/wpengine/README.md
+++ b/workflows/wpengine/README.md
@@ -1,13 +1,14 @@
 # WP Engine Deployment GitHub Actions
 
 ## WP Engine Deployment Workflows
-We have 3 deployment workflows to interface with whatever hosting environment is needed (deploy-dev.yml,
-deploy-stage.yml, deploy-prod.yml). You will need to update the `[DEV|STAGE|PROD]_DEPLOY_REPO`,
-`DEPLOY_PRIVATE_SSH_KEY`, and 1Password secrets (`OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, `OP_ITEM`) to use these
-deployments in your project. These are intended to be deploying to the hosting service where the site will live. Most
-hosting companies work with `git` making it the default push we currently use.
+We have three deployment workflows to interface with whatever hosting environment is needed (`deploy-dev.yml`,
+`deploy-stage.yml`, `deploy-prod.yml`). You will need to update the `WPE_SSHG_KEY_PRIVATE` and 1Password secrets
+(`OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, `OP_ITEM`) to use these deployments in your project.
+These are intended to be deploying to the hosting service where the site will live. Most hosting companies work
+with `git` making it the default push we currently use.
 
 ## Setup Instructions
-1. Copy & Paste the `wpe-deploy-*.yml` file into your projects `.github/workflows` directory to take advantage of this action.
-2. These workflows rely on the `composer-install` action [from Moose]([url](https://github.com/moderntribe/moose/tree/main/.github/actions)). Be sure your project is also using them or that you're replicated that functionality in your local project.
-3. You will need to update the `WPE_DEPLOY_REPO`, `DEPLOY_PRIVATE_SSH_KEY`, `COMPOSER_AUTH_JSON`, and `COMPOSER_ENV` secrets to use this deployment in your project.
+1. Copy and paste the `wpe-deploy-*.yml` file into your projects `.github/workflows` directory to take advantage of this action.
+2. These workflows rely on the `composer-install` action [from Moose]([url](https://github.com/moderntribe/moose/tree/main/.github/actions)).
+Be sure your project is also using them or that you're replicated that functionality in your local project.
+3. You will need to define the `WPE_SSHG_KEY_PRIVATE`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, and `OP_ITEM` secrets to use this deployment in your project.

--- a/workflows/wpengine/README.md
+++ b/workflows/wpengine/README.md
@@ -9,6 +9,7 @@ with `git` making it the default push we currently use.
 
 ## Setup Instructions
 1. Copy and paste the `wpe-deploy-*.yml` file into your project's `.github/workflows` directory to take advantage of this action.
-2. These workflows rely on the `composer-install` action [from Moose]([url](https://github.com/moderntribe/moose/tree/main/.github/actions)).
+2. Remove `node_modules` line from `.deploy/deploy-exclude.txt`.
+3. These workflows rely on the `composer-install` action [from ModernPress]([url](https://github.com/moderntribe/modernpress/tree/main/.github/actions)).
 Be sure your project is also using them or that you're replicated that functionality in your local project.
-3. You will need to define the `WPE_SSHG_KEY_PRIVATE`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, and `OP_ITEM` secrets to use this deployment in your project.
+4. You will need to define the `WPE_SSHG_KEY_PRIVATE`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, and `OP_ITEM` secrets to use this deployment in your project.

--- a/workflows/wpengine/README.md
+++ b/workflows/wpengine/README.md
@@ -8,7 +8,7 @@ These are intended to be deploying to the hosting service where the site will li
 with `git` making it the default push we currently use.
 
 ## Setup Instructions
-1. Copy and paste the `wpe-deploy-*.yml` file into your projects `.github/workflows` directory to take advantage of this action.
+1. Copy and paste the `wpe-deploy-*.yml` file into your project's `.github/workflows` directory to take advantage of this action.
 2. These workflows rely on the `composer-install` action [from Moose]([url](https://github.com/moderntribe/moose/tree/main/.github/actions)).
 Be sure your project is also using them or that you're replicated that functionality in your local project.
 3. You will need to define the `WPE_SSHG_KEY_PRIVATE`, `OP_SERVICE_ACCOUNT_TOKEN`, `OP_VAULT`, and `OP_ITEM` secrets to use this deployment in your project.

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -21,6 +21,8 @@ jobs:
       # Get Build Repository
       - name: Check out build branch
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       # Composer install
       - name: 'Composer install'
@@ -34,7 +36,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: "./.nvmrc"
           cache: 'npm'
           check-latest: true
 

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -1,4 +1,5 @@
-name: WPE Deploy Dev
+name: Deploy to dev
+run-name: Deploy `${{ github.head_ref || github.ref_name }}` to `${{ env.WPE_ENV }}`
 
 on:
   workflow_dispatch:

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Get Build Repository
       - name: Check out build branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Composer install
       - name: 'Composer install'
@@ -32,7 +32,7 @@ jobs:
 
       # Set up node version
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Create local config
         run: |
           php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
-          echo "define( 'WP_ENVIRONMENT_TYPE', ${{ env.ENVIRONMENT }} );" >> local-config.php
+          FILE="local-config.php"
+          (head -n 1 "$FILE" && printf '// Added by GitHub Actions CI\ndefine( "WP_ENVIRONMENT_TYPE", "%s" );\n\n' "${{ env.ENVIRONMENT }}" && tail -n +2 "$FILE") > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+          echo "First 8 lines after update:" && head -n 8 "$FILE"
 
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -1,6 +1,10 @@
 name: Deploy to dev
 run-name: Deploy `${{ github.head_ref || github.ref_name }}` to `${{ env.WPE_ENV }}`
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
 

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -38,12 +38,15 @@ jobs:
           cache: 'npm'
           check-latest: true
 
-      # NPM Install and Build
-      - name: NPM Install
-        run: npm install
+      # NPM install all dependencies and build assets
+      - name: NPM install and build assets
+        run: |
+          npm install
+          npm run dist
 
-      - name: NPM Build
-        run: npm run dist
+      # NPM install production dependencies
+      - name: NPM install production dependencies
+        run: npm install --omit=dev --omit=optional
 
       # Create local config for environment based settings
       - name: Create local config

--- a/workflows/wpengine/wpe-deploy-dev.yml
+++ b/workflows/wpengine/wpe-deploy-dev.yml
@@ -50,14 +50,6 @@ jobs:
       - name: NPM install production dependencies
         run: npm install --omit=dev --omit=optional
 
-      # Create local config for environment based settings
-      - name: Create local config
-        run: |
-          php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
-          FILE="local-config.php"
-          (head -n 1 "$FILE" && printf '// Added by GitHub Actions CI\ndefine( "WP_ENVIRONMENT_TYPE", "%s" );\n\n' "${{ env.ENVIRONMENT }}" && tail -n +2 "$FILE") > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-          echo "First 8 lines after update:" && head -n 8 "$FILE"
-
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.
 

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Create local config
         run: |
           php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
-          echo "define( 'WP_ENVIRONMENT_TYPE', ${{ env.ENVIRONMENT }} );" >> local-config.php
+          FILE="local-config.php"
+          (head -n 1 "$FILE" && printf '// Added by GitHub Actions CI\ndefine( "WP_ENVIRONMENT_TYPE", "%s" );\n\n' "${{ env.ENVIRONMENT }}" && tail -n +2 "$FILE") > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+          echo "First 8 lines after update:" && head -n 8 "$FILE"
 
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Get Build Repository
       - name: Check out build branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Composer install
       - name: 'Composer install'
@@ -34,7 +34,7 @@ jobs:
 
       # Set up node version
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -1,6 +1,10 @@
 name: Deploy to production
 run-name: Deploy `${{ github.head_ref || github.ref_name }}` to production
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
 #  push:
 #    branches:

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -1,4 +1,5 @@
-name: Deploy Production
+name: Deploy to production
+run-name: Deploy `${{ github.head_ref || github.ref_name }}` to production
 
 on:
 #  push:

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -40,12 +40,15 @@ jobs:
           cache: 'npm'
           check-latest: true
 
-      # NPM Install and Build
-      - name: NPM Install
-        run: npm install
+      # NPM install all dependencies and build assets
+      - name: NPM install and build assets
+        run: |
+          npm install
+          npm run dist
 
-      - name: NPM Build
-        run: npm run dist
+      # NPM install production dependencies
+      - name: NPM install production dependencies
+        run: npm install --omit=dev --omit=optional
 
       # Create local config for environment based settings
       - name: Create local config

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
 #  push:
 #    branches:
-#      - server/production
+#      - main
 
 jobs:
   deploy:
@@ -23,6 +23,8 @@ jobs:
       # Get Build Repository
       - name: Check out build branch
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       # Composer install
       - name: 'Composer install'
@@ -36,7 +38,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: "./.nvmrc"
           cache: 'npm'
           check-latest: true
 

--- a/workflows/wpengine/wpe-deploy-prod.yml
+++ b/workflows/wpengine/wpe-deploy-prod.yml
@@ -52,14 +52,6 @@ jobs:
       - name: NPM install production dependencies
         run: npm install --omit=dev --omit=optional
 
-      # Create local config for environment based settings
-      - name: Create local config
-        run: |
-          php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
-          FILE="local-config.php"
-          (head -n 1 "$FILE" && printf '// Added by GitHub Actions CI\ndefine( "WP_ENVIRONMENT_TYPE", "%s" );\n\n' "${{ env.ENVIRONMENT }}" && tail -n +2 "$FILE") > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-          echo "First 8 lines after update:" && head -n 8 "$FILE"
-
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.
 

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -1,4 +1,5 @@
-name: Deploy Staging
+name: Deploy to staging
+run-name: Deploy `${{ github.head_ref || github.ref_name }}` to `${{ env.WPE_ENV }}`
 
 on:
 #  push:

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Create local config
         run: |
           php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
-          echo "define( 'WP_ENVIRONMENT_TYPE', ${{ env.ENVIRONMENT }} );" >> local-config.php
+          FILE="local-config.php"
+          (head -n 1 "$FILE" && printf '// Added by GitHub Actions CI\ndefine( "WP_ENVIRONMENT_TYPE", "%s" );\n\n' "${{ env.ENVIRONMENT }}" && tail -n +2 "$FILE") > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+          echo "First 8 lines after update:" && head -n 8 "$FILE"
 
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Get Build Repository
       - name: Check out build branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Composer install
       - name: 'Composer install'
@@ -34,7 +34,7 @@ jobs:
 
       # Set up node version
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -40,12 +40,15 @@ jobs:
           cache: 'npm'
           check-latest: true
 
-      # NPM Install and Build
-      - name: NPM Install
-        run: npm install
+      # NPM install all dependencies and build assets
+      - name: NPM install and build assets
+        run: |
+          npm install
+          npm run dist
 
-      - name: NPM Build
-        run: npm run dist
+      # NPM install production dependencies
+      - name: NPM install production dependencies
+        run: npm install --omit=dev --omit=optional
 
       # Create local config for environment based settings
       - name: Create local config

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -6,9 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-#  push:
-#    branches:
-#      - server/staging
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -23,6 +23,8 @@ jobs:
       # Get Build Repository
       - name: Check out build branch
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       # Composer install
       - name: 'Composer install'
@@ -36,7 +38,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: "./.nvmrc"
           cache: 'npm'
           check-latest: true
 

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -1,6 +1,10 @@
 name: Deploy to staging
 run-name: Deploy `${{ github.head_ref || github.ref_name }}` to `${{ env.WPE_ENV }}`
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 on:
 #  push:
 #    branches:

--- a/workflows/wpengine/wpe-deploy-stage.yml
+++ b/workflows/wpengine/wpe-deploy-stage.yml
@@ -50,14 +50,6 @@ jobs:
       - name: NPM install production dependencies
         run: npm install --omit=dev --omit=optional
 
-      # Create local config for environment based settings
-      - name: Create local config
-        run: |
-          php -r "file_exists( 'local-config.php' ) || copy( 'local-config-sample.php', 'local-config.php' );"
-          FILE="local-config.php"
-          (head -n 1 "$FILE" && printf '// Added by GitHub Actions CI\ndefine( "WP_ENVIRONMENT_TYPE", "%s" );\n\n' "${{ env.ENVIRONMENT }}" && tail -n +2 "$FILE") > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-          echo "First 8 lines after update:" && head -n 8 "$FILE"
-
       ##########
       ### DEPLOY: Use the WPE git deploy hook method. TLDR; rsync our repo on their repo and push.
 


### PR DESCRIPTION
# What does this do/fix?

1. Adds Pantheon deployment workflow using official Pantheon GitHub action.
2. Updates WP Engine deployment workflows and readme.

# How can this be quickly implemented for testing?

Follow the included deployment workflow instructions on a project hosted on Pantheon or WP Engine, and run each deployment workflow.